### PR TITLE
Update version README with go version requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ nuru
 Notes.md
 tutorials/en/*
 config.json
+
+# For Nuru executables
+/nuru
+/Nuru

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ nuru -v
 
 ### Building From Source
 
- - Make sure you have golang installed
+ - Make sure you have golang installed (atleast 1.19.0 and above)
  - Run the following command:
 
 ```


### PR DESCRIPTION
Add go version requirement for building onto README with go version minimum as 1.19 because [bubblezone](https://github.com/lrstanley/bubblezone) uses a go 1.19 feature of atomic.Bool not available in 1.18 which is what comes by default on current ubuntu 22.04 LTS which I believe is what most people use.

